### PR TITLE
Fix some symbol/dialect registration

### DIFF
--- a/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
+++ b/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRBase.td
@@ -115,7 +115,7 @@ def eir_HeapBinType : eir_TermType<eir_TK_HeapBin, "heapbin term">;
 def eir_ProcBinType : eir_TermType<eir_TK_ProcBin, "procbin term">;
 def eir_BoxType : eir_TermType<eir_TK_Box, "boxed term">;
 
-def eir_AnyTerm : Type<CPred<"$_self.isa<eir::TermType>()">>;
+def eir_AnyTerm : Type<CPred<"$_self.isa<eir::TermType>()">, "any term">;
 def eir_BoolLike : AnyTypeOf<[I1, eir_BoolType]>;
 def eir_FixnumLike : AnyTypeOf<[I32, I64, eir_FixnumType]>;
 def eir_FloatLike : AnyTypeOf<[F64, eir_FixnumType]>;

--- a/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
+++ b/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIRDialect.cpp
@@ -32,7 +32,6 @@ EirDialect::EirDialect(mlir::MLIRContext *ctx)
            ListType,
            NumberType,
            IntegerType,
-           BinaryType,
            AtomType,
            BooleanType,
            FixnumType,

--- a/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
+++ b/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
@@ -7,7 +7,6 @@ include "lumen/compiler/Dialect/EIR/IR/EIRBase.td"
 
 def eir_FuncOp : eir_Op<"func", [
     IsolatedFromAbove,
-    HasParent<"ModuleOp">,
     FunctionLike,
     CallableOpInterface,
     Symbol,

--- a/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
+++ b/liblumen_codegen/lib/lumen/compiler/Dialect/EIR/IR/EIROps.td
@@ -526,7 +526,7 @@ def eir_CondBranchOp : eir_Op<"cond_br", [Terminator]> {
 class eir_CallBaseOp<string mnemonic, list<OpTrait> traits = []> :
     eir_Op<mnemonic, !listconcat(traits, [CallOpInterface])> {
   let extraClassDeclaration = [{
-    StringRef getCallee() { return callee(); }
+    SymbolRefAttr getCallee() { return callee(); }
 
     /// Get the argument operands to the called function.
     operand_range getArgOperands() {
@@ -549,7 +549,7 @@ def eir_CallOp : eir_CallBaseOp<"call"> {
   }];
 
   let arguments = (ins
-    eir_FuncRefAttr:$callee,
+    SymbolRefAttr:$callee,
     Variadic<eir_AnyTerm>:$operands
   );
   let results = (outs
@@ -571,20 +571,13 @@ def eir_CallOp : eir_CallBaseOp<"call"> {
       result.addTypes(callee.getType().getResults());
     }]>,
     OpBuilder<[{
-      Builder *builder, OperationState &result, FlatSymbolRefAttr callee,
+      Builder *builder, OperationState &result, SymbolRefAttr callee,
       ArrayRef<Type> resultTypes, ValueRange operands = {}
     }], [{
       result.addOperands(operands);
       result.addAttribute("callee", callee);
       result.addTypes(resultTypes);
-    }]>,
-    OpBuilder<[{
-      Builder *builder, OperationState &result, StringRef callee,
-      ArrayRef<Type> resultTypes, ValueRange operands = {}
-    }], [{
-      build(builder, result, builder->getSymbolRefAttr(callee),
-            resultTypes, operands);
-    }]>,
+    }]>
   ];
 
   let verifier = [{ /*TODO*/return success(); }];

--- a/liblumen_codegen/lib/lumen/compiler/Support/Options.cpp
+++ b/liblumen_codegen/lib/lumen/compiler/Support/Options.cpp
@@ -20,7 +20,4 @@ void LLVMLumenSetLLVMOptions(int argc, char **argv) {
 
   mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv);
-
-  // Register the EIR dialect with MLIR
-  mlir::registerDialect<eir::EirDialect>();
 }

--- a/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
+++ b/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
@@ -200,7 +200,7 @@ MLIRModuleBuilderRef MLIRCreateModuleBuilder(MLIRContextRef context,
 ModuleBuilder::ModuleBuilder(MLIRContext &context, StringRef name, const TargetMachine *targetMachine)
   : builder(&context), targetMachine(targetMachine) {
   // Create an empty module into which we can codegen functions
-  theModule = builder.create<mlir::ModuleOp>(builder.getUnknownLoc(), name);
+  theModule = mlir::ModuleOp::create(builder.getUnknownLoc(), name);
 }
 
 extern "C"

--- a/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
+++ b/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.cpp
@@ -204,6 +204,12 @@ ModuleBuilder::ModuleBuilder(MLIRContext &context, StringRef name, const TargetM
 }
 
 extern "C"
+void MLIRDumpFunction(MLIRFunctionOpRef f) {
+  FuncOp *func_op = unwrap(f);
+  func_op->dump();
+}
+
+extern "C"
 void MLIRDumpModule(MLIRModuleBuilderRef b) {
   ModuleBuilder *builder = unwrap(b);
   builder->dump();
@@ -322,6 +328,12 @@ MLIRValueRef MLIRGetCurrentBlockArgument(MLIRModuleBuilderRef b, unsigned id) {
     Block *block = builder->getBlock();
     assert(block != nullptr);
     return wrap(block->getArgument(id));
+}
+
+extern "C"
+MLIRBlockRef MLIRGetCurrentBlock(MLIRModuleBuilderRef b) {
+    ModuleBuilder *builder = unwrap(b);
+    return wrap(builder->getBlock());
 }
 
 Block *ModuleBuilder::getBlock() {
@@ -506,7 +518,7 @@ void ModuleBuilder::build_match(Match op) {
     MatchBranch branch(dest, destArgs, std::move(pattern));
     branches.push_back(std::move(branch));
   }
-  
+
   // Create the operation using the internal representation
   builder.create<MatchOp>(builder.getUnknownLoc(),
                           selector,

--- a/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.h
+++ b/liblumen_codegen/lib/lumen/compiler/Translation/ModuleBuilder.h
@@ -208,7 +208,8 @@ public:
   void build_return(Value value);
 
   void build_static_call(
-    StringRef target,
+    StringRef module,
+    StringRef nameArity,
     ArrayRef<Value> args,
     bool isTail,
     Block *ok,

--- a/liblumen_codegen/src/mlir/builder/ffi.rs
+++ b/liblumen_codegen/src/mlir/builder/ffi.rs
@@ -359,7 +359,8 @@ extern "C" {
 
     pub fn MLIRBuildStaticCall(
         builder: ModuleBuilderRef,
-        name: *const libc::c_char,
+        module: *const libc::c_char,
+        name_arity: *const libc::c_char,
         argv: *const ValueRef,
         argc: libc::c_uint,
         is_tail: bool,

--- a/liblumen_codegen/src/mlir/builder/ffi.rs
+++ b/liblumen_codegen/src/mlir/builder/ffi.rs
@@ -282,6 +282,7 @@ extern "C" {
         target_machine: llvm::TargetMachineRef,
     ) -> ModuleBuilderRef;
 
+    pub fn MLIRDumpFunction(functon_op: FunctionOpRef);
     pub fn MLIRDumpModule(builder: ModuleBuilderRef);
 
     pub fn MLIRFinalizeModuleBuilder(builder: ModuleBuilderRef) -> ModuleRef;
@@ -314,6 +315,8 @@ extern "C" {
     //---------------
     // Blocks
     //---------------
+
+    pub fn MLIRGetCurrentBlock(builder: ModuleBuilderRef) -> BlockRef;
 
     pub fn MLIRGetCurrentBlockArgument(builder: ModuleBuilderRef, id: libc::c_uint) -> ValueRef;
 
@@ -443,22 +446,10 @@ extern "C" {
     // Constants
     //---------------
 
-    pub fn MLIRBuildConstantFloat(
-        builder: ModuleBuilderRef,
-        value: f64,
-    ) -> ValueRef;
-    pub fn MLIRBuildFloatAttr(
-        builder: ModuleBuilderRef,
-        value: f64,
-    ) -> AttributeRef;
-    pub fn MLIRBuildConstantInt(
-        builder: ModuleBuilderRef,
-        value: i64,
-    ) -> ValueRef;
-    pub fn MLIRBuildIntAttr(
-        builder: ModuleBuilderRef,
-        value: i64,
-    ) -> AttributeRef;
+    pub fn MLIRBuildConstantFloat(builder: ModuleBuilderRef, value: f64) -> ValueRef;
+    pub fn MLIRBuildFloatAttr(builder: ModuleBuilderRef, value: f64) -> AttributeRef;
+    pub fn MLIRBuildConstantInt(builder: ModuleBuilderRef, value: i64) -> ValueRef;
+    pub fn MLIRBuildIntAttr(builder: ModuleBuilderRef, value: i64) -> AttributeRef;
     pub fn MLIRBuildConstantBigInt(
         builder: ModuleBuilderRef,
         value: *const libc::c_char,

--- a/liblumen_codegen/src/mlir/builder/function.rs
+++ b/liblumen_codegen/src/mlir/builder/function.rs
@@ -190,10 +190,10 @@ pub struct ScopedFunctionBuilder<'f, 'o> {
 #[macro_export]
 macro_rules! debug_in {
     ($this:expr, $format:expr) => {
-        debug!("{}: {}", $this.name(), $format);
+        debug!("{}: {}", $this.ident(), $format);
     };
     ($this:expr, $format:expr, $($arg:expr),+) => {
-        debug!("{}: {}", $this.name(), &format!($format, $($arg),+));
+        debug!("{}: {}", $this.ident(), &format!($format, $($arg),+));
     }
 }
 
@@ -211,14 +211,14 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
 
     /// Returns the current function identifier
     #[inline]
-    pub fn name(&self) -> &FunctionIdent {
-        self.func.name()
+    pub fn ident(&self) -> &FunctionIdent {
+        self.func.ident()
     }
 
     /// Prints debugging messages with the name of the function being built
     #[cfg(debug_assertions)]
     pub(super) fn debug(&self, message: &str) {
-        debug!("{}: {}", self.name(), message);
+        debug!("{}: {}", self.ident(), message);
     }
 
     #[cfg(not(debug_assertions))]
@@ -433,7 +433,7 @@ impl<'f, 'o> ScopedFunctionBuilder<'f, 'o> {
 
     /// Returns true if the given symbol is the same as the current functions' module name
     pub fn is_current_module(&self, m: Symbol) -> bool {
-        self.func.name().module.name == m
+        self.func.ident().module.name == m
     }
 
     /// Returns the current block arguments as values

--- a/liblumen_codegen/src/mlir/builder/function.rs
+++ b/liblumen_codegen/src/mlir/builder/function.rs
@@ -19,8 +19,8 @@ use libeir_util_datastructures::pooled_entity_set::BoundEntitySet;
 
 use crate::Result;
 
-use liblumen_session::Options;
 use liblumen_core::symbols::FunctionSymbol;
+use liblumen_session::Options;
 
 use super::block::{Block, BlockData};
 use super::ffi::*;
@@ -84,7 +84,16 @@ impl<'a, 'm, 'f> FunctionBuilder<'a, 'm, 'f> {
                 self.with_scope(fi, loc, f, &analysis, data, options)
                     .and_then(|scope| scope.build())?
             };
+            // if format!("{}", &ident) == "init:module_info/0" {
+            //     debug!("SKIPPING ADDING {}", &ident);
+            //     continue;
+            // }
+            debug!("ADDING {}", &ident);
+            unsafe {
+                MLIRDumpFunction(func);
+            }
             unsafe { MLIRAddFunction(self.builder.as_ref(), func) }
+            debug!("ADDED {}", &ident);
         }
 
         Ok(())

--- a/liblumen_codegen/src/mlir/builder/ops/builders/call.rs
+++ b/liblumen_codegen/src/mlir/builder/ops/builders/call.rs
@@ -15,7 +15,8 @@ impl CallBuilder {
                 builder.debug(&format!("static call target is {}", ident));
 
                 let is_local = builder.is_current_module(ident.module.name);
-                let name = CString::new(ident.to_string()).unwrap();
+                let module = CString::new(ident.module.to_string()).unwrap();
+                let name = CString::new(format!("{}/{}", ident.name, ident.arity)).unwrap();
                 let args = op
                     .args
                     .iter()
@@ -48,6 +49,7 @@ impl CallBuilder {
                 unsafe {
                     MLIRBuildStaticCall(
                         builder.as_ref(),
+                        module.as_ptr(),
                         name.as_ptr(),
                         args.as_ptr(),
                         args.len() as libc::c_uint,


### PR DESCRIPTION
# Changelog
## Bug Fixes
* Remove duplicate `BinaryType` in `addTypes` to fix `error: dialect symbol already registered`.
* Remove redundant `registerDialect` call.  `EirDialect` is registered statically now, so this call caused `LLVM ERROR: a dialect with namespace 'eir' has already been registered`.