### PR TITLE
Pass args: Vec<String> to lumen_entry

### DIFF
--- a/liblumen_crt/src/lib.rs
+++ b/liblumen_crt/src/lib.rs
@@ -1,11 +1,12 @@
 #![feature(main)]
 
+use std::ffi::CStr;
 use std::panic;
 
 mod atoms;
 mod symbols;
 
-extern "C" {
+extern "Rust" {
     /// The target-defined entry point for the generated executable.
     ///
     /// Each target has its own runtime crate, which uses `#[entry]` from
@@ -13,12 +14,21 @@ extern "C" {
     /// called after the atom table, and any other core runtime functionality,
     /// is initialized and ready for use.
     #[link_name = "lumen_entry"]
-    fn lumen_entry() -> i32;
+    fn lumen_entry(args: Vec<String>) -> i32;
 }
 
 #[no_mangle]
 pub extern "C" fn main(argc: i32, argv: *const *const std::os::raw::c_char) -> i32 {
-    let exit_code = panic::catch_unwind(move || main_internal());
+    let args = (0..(argc as isize))
+        .map(|i| {
+            unsafe { CStr::from_ptr(*argv.offset(i) as *const std::os::raw::c_char) }
+                .to_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect();
+
+    let exit_code = panic::catch_unwind(move || main_internal(args));
     exit_code.unwrap_or(101)
 }
 
@@ -29,7 +39,7 @@ pub extern "C" fn main(argc: i32, argv: *const *const std::os::raw::c_char) -> i
 /// this function invokes the platform-specific entry point which handles starting
 /// up the schedulers and other high-level runtime functionality.
 #[main]
-pub fn main_internal() -> i32 {
+pub fn main_internal(args: Vec<String>) -> i32 {
     use crate::atoms::*;
     use crate::symbols::*;
 
@@ -44,5 +54,5 @@ pub fn main_internal() -> i32 {
     }
 
     // Invoke platform-specific entry point
-    unsafe { lumen_entry() }
+    unsafe { lumen_entry(args) }
 }

--- a/lumen_runtime/src/lib.rs
+++ b/lumen_runtime/src/lib.rs
@@ -75,21 +75,21 @@ mod timer;
 /// but for now it is sufficient to just conditionally compile the entry point here
 #[cfg(not(any(test, target_arch = "wasm32")))]
 #[liblumen_core::entry]
-fn main() -> impl ::std::process::Termination + 'static {
+fn main(args: Vec<String>) -> impl ::std::process::Termination + 'static {
     let name = env!("CARGO_PKG_NAME");
     let version = env!("CARGO_PKG_VERSION");
-    main_internal(name, version, std::env::args().collect())
+    main_internal(name, version, args)
 }
 
 #[cfg(not(any(test, target_arch = "wasm32")))]
 fn main_internal(name: &str, version: &str, argv: Vec<String>) -> Result<(), ()> {
-    use std::thread;
-    use bus::Bus;
-    use log::Level;
     use self::config::Config;
     use self::logging::Logger;
-    use self::system::break_handler::{self, Signal};
     use self::scheduler::Scheduler;
+    use self::system::break_handler::{self, Signal};
+    use bus::Bus;
+    use log::Level;
+    use std::thread;
 
     // Load system configuration
     let _config = match Config::from_argv(name.to_string(), version.to_string(), argv) {
@@ -136,7 +136,7 @@ fn main_internal(name: &str, version: &str, argv: Vec<String>) -> Result<(), ()>
                 }
                 // All other signals can be surfaced to other parts of the
                 // system for custom use, e.g. SIGCHLD, SIGALRM, SIGUSR1/2
-                _ => ()
+                _ => (),
             }
         }
         // If the scheduler scheduled a process this cycle, then we're busy

--- a/lumen_web/src/lib.rs
+++ b/lumen_web/src/lib.rs
@@ -36,7 +36,7 @@ use crate::window::add_event_listener;
 /// Starts the scheduler loop.  It yield and reschedule itself using
 /// [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).
 #[cfg_attr(not(test), entry)]
-pub fn start() {
+pub fn start(_args: Vec<String>) {
     add_event_listeners();
     request_animation_frames();
 }

--- a/runtimes/minimal/src/lib.rs
+++ b/runtimes/minimal/src/lib.rs
@@ -10,11 +10,11 @@ compile_error!("lumen_rt_minimal is only supported on unix targets!");
 #[macro_use]
 mod macros;
 mod config;
+mod distribution;
 mod logging;
+mod process;
 mod scheduler;
 mod sys;
-mod distribution;
-mod process;
 
 use bus::Bus;
 use log::Level;
@@ -27,10 +27,10 @@ use self::scheduler::Scheduler;
 use self::sys::break_handler::{self, Signal};
 
 #[liblumen_core::entry]
-fn main() -> impl ::std::process::Termination + 'static {
+fn main(args: Vec<String>) -> impl ::std::process::Termination + 'static {
     let name = env!("CARGO_PKG_NAME");
     let version = env!("CARGO_PKG_VERSION");
-    main_internal(name, version, std::env::args().collect())
+    main_internal(name, version, args)
 }
 
 fn main_internal(name: &str, version: &str, argv: Vec<String>) -> Result<(), ()> {
@@ -39,7 +39,6 @@ fn main_internal(name: &str, version: &str, argv: Vec<String>) -> Result<(), ()>
         Ok(config) => config,
         Err(err) => {
             panic!("Config error: {}", err);
-            return Err(());
         }
     };
 


### PR DESCRIPTION
Bypasses segfault and leads to new error:

```
ModuleFunctionArity { module: :"init", function: :"startassertion failed: `(left == right)`\n  left: ``,\n right: ``: destination and source slices have different lengths/rustc/19bd93467617a447c22ec32cc1cf14d40cb84ccf/src/libcore/macros/mod.rscalled `Result::unwrap()` on an `Err` value", arity: 0 }
atom(id = 0, value = 'false')
atom(id = 61, value = 'startassertion failed: `(left == right)`
  left: ``,
 right: ``: destination and source slices have different lengths/rustc/19bd93467617a447c22ec32cc1cf14d40cb84ccf/src/libcore/macros/mod.rscalled `Result::unwrap()` on an `Err` value')
atom(id = 60, value = 'init')
atom(id = 1, value = 'true')
thread '<unnamed>' panicked at 'invalid mfa provided for process (fun init:start/0), no such symbol found', runtimes/minimal/src/scheduler.rs:489:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```